### PR TITLE
Added custom copyright and enabling MathJax option

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -6,6 +6,7 @@ baseurl = "https://example.com"
 [params]
 description = "A clean Hugo theme for websites"
 # logoimage = "images/logo.jpg"
+# copyright = "foo"
 
 [permalinks]
 blog  = "/blog/:year/:month/:title/"

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -8,6 +8,11 @@ description = "A clean Hugo theme for websites"
 # logoimage = "images/logo.jpg"
 # copyright = "foo"
 
+# mathjax = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"
+## Uncomment if you want mathjax enabled. The above cdn source is taken from https://gohugo.io/content-management/formats/#mathjax-with-hugo   
+
+
+
 [permalinks]
 blog  = "/blog/:year/:month/:title/"
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -3,7 +3,7 @@
       </div>
 
       <div id="footer">
-        Copyright {{ now.Year }} {{ .Site.Title }}
+        Copyright {{ now.Year }} {{ $.Site.Params.copyright }}
       </div>
 
     </div>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -5,6 +5,14 @@
     <link rel="stylesheet" href="{{ .Site.BaseURL }}css/crab.css">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=0.5, maximum-scale=3.0">
     {{ .Hugo.Generator }}
+
+
+
+    {{ if isset .Site.Params "mathjax"}}
+    <script type="text/javascript" src="{{ .Site.Params.mathjax }}">
+    </script>
+    {{end}}
+
   </head>
   <body>
 


### PR DESCRIPTION
Hello,

- The theme currently puts the title of the website into the copyright. I created a `copyright`  variable which can be customised. So copyright holder can be something different than the owner.  

- Added  a mathjax variable that allows the option to enable mathjax. We use a script to load mathjax - [as explained here](https://gohugo.io/content-management/formats/#mathjax-with-hugo). 