### PR TITLE
Set default encoding as utf-8 and add support for google analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ site generator.
 - two-column
 - tag support
 - blog articles
+- Google analytics tag.
+- EU Cookies consent warning
 
 ## Preview
 

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -8,8 +8,11 @@ description = "A clean Hugo theme for websites"
 # logoimage = "images/logo.jpg"
 # copyright = "foo"
 
+# google_analytics = "UA-xxxxxxx-X"
+## Uncomment if you have a google analytics tag and want to enable it.
+
 # mathjax = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"
-## Uncomment if you want mathjax enabled. The above cdn source is taken from https://gohugo.io/content-management/formats/#mathjax-with-hugo   
+## Uncomment if you want mathjax enabled. The above cdn source is taken from https://gohugo.io/content-management/formats/#mathjax-with-hugo
 
 
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -8,5 +8,17 @@
 
     </div>
 
+    {{ if isset .Site.Params "google_analytics"}}
+      <!-- Global site tag (gtag.js) - Google Analytics -->
+      <script async src="https://www.googletagmanager.com/gtag/js?id={{ .Site.Params.google_analytics}}"></script>
+      <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', '{{ .Site.Params.google_analytics}}');
+      </script>
+    {{end}}
+
   </body>
 </html>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -8,6 +8,13 @@
 
     </div>
 
+    <div id="cookieConsent">
+        <div id="closeCookieConsent">x</div>
+        This website is using cookies so we can deliver a better experience. <a href="https://cookiesandyou.com/" target="_blank">More info</a>. <a class="cookieConsentOK">I understand</a>
+    </div>
+
+    <script type="text/javascript" src="{{ .Site.BaseURL }}js/cookie_consent.js"></script>
+
     {{ if isset .Site.Params "google_analytics"}}
       <!-- Global site tag (gtag.js) - Google Analytics -->
       <script async src="https://www.googletagmanager.com/gtag/js?id={{ .Site.Params.google_analytics}}"></script>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -3,6 +3,7 @@
   <head>
     <title>{{ .Title }} - {{ .Site.Title }}</title>
     <link rel="stylesheet" href="{{ .Site.BaseURL }}css/crab.css">
+    <link rel="stylesheet" href="{{ .Site.BaseURL }}css/cookie_consent.css">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=0.5, maximum-scale=3.0">
     <meta charset="utf-8">
     {{ .Hugo.Generator }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -4,6 +4,7 @@
     <title>{{ .Title }} - {{ .Site.Title }}</title>
     <link rel="stylesheet" href="{{ .Site.BaseURL }}css/crab.css">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=0.5, maximum-scale=3.0">
+    <meta charset="utf-8">
     {{ .Hugo.Generator }}
 
 

--- a/static/css/cookie_consent.css
+++ b/static/css/cookie_consent.css
@@ -1,0 +1,46 @@
+/*Cookie Consent Begin*/
+#cookieConsent {
+    background-color: rgba(20,20,20,0.8);
+    min-height: 26px;
+    font-size: 14px;
+    color: #ccc;
+    line-height: 26px;
+    padding: 8px 0 8px 30px;
+    font-family: "Trebuchet MS",Helvetica,sans-serif;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    display: none;
+    z-index: 9999;
+}
+#cookieConsent a {
+    color: #4B8EE7;
+    text-decoration: none;
+}
+#closeCookieConsent {
+    float: right;
+    display: inline-block;
+    cursor: pointer;
+    height: 20px;
+    width: 20px;
+    margin: -15px 0 0 0;
+    font-weight: bold;
+}
+#closeCookieConsent:hover {
+    color: #FFF;
+}
+#cookieConsent a.cookieConsentOK {
+    background-color: #F1D600;
+    color: #000;
+    display: inline-block;
+    border-radius: 5px;
+    padding: 0 20px;
+    cursor: pointer;
+    float: right;
+    margin: 0 60px 0 10px;
+}
+#cookieConsent a.cookieConsentOK:hover {
+    background-color: #E0C91F;
+}
+/*Cookie Consent End*/

--- a/static/js/cookie_consent.js
+++ b/static/js/cookie_consent.js
@@ -1,0 +1,12 @@
+document.addEventListener('DOMContentLoaded', function(){
+    const cookiesCompliance = sessionStorage.getItem('cookiesCompliance');
+    if (cookiesCompliance === 'true') return;
+
+    setTimeout(function () {
+        document.getElementById("cookieConsent").setAttribute('style', 'display: block;')
+     }, 4000);
+     document.getElementsByClassName('cookieConsentOK')[0].onclick = () => {
+       document.getElementById("cookieConsent").setAttribute('style', 'display: none;');
+       sessionStorage.setItem('cookiesCompliance', 'true');
+     };
+}, false);


### PR DESCRIPTION
I'm adding three features:

* Set default page encoding to utf-8. This allows the usage of emojis :+1:  :smile: and other symbols without problem.
* Add support for the google analytics tracking tag. Like the _mathjax_ feature, it's enabled by adding the param to the config file.
* Add the cookies consent warning. It's enabled by default, though if the gAnalytics tag isn't enabled there won't be any cookies created.

PT: Thanks for this template!