### PR TITLE
let summary support markdown

### DIFF
--- a/layouts/shortcodes/summary.html
+++ b/layouts/shortcodes/summary.html
@@ -1,3 +1,3 @@
 <div id="summary">
-  {{ .Inner }}
+  {{ .Inner | markdownify }}
 </div>


### PR DESCRIPTION
Just found that summary content can not render markdown
Simply add a markdownify in summary.html to make it.